### PR TITLE
Added a `tempered_sample` helper function and no-swap burn-in functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 

--- a/src/MCMCTempering.jl
+++ b/src/MCMCTempering.jl
@@ -4,6 +4,7 @@ import AbstractMCMC
 import Distributions
 import Random
 
+using ProgressLogging: ProgressLogging
 using ConcreteStructs: @concrete
 using Setfield: @set, @set!
 
@@ -13,13 +14,15 @@ using DocStringExtensions
 
 include("adaptation.jl")
 include("swapping.jl")
-include("states.jl")
-include("tempered.jl")
+include("state.jl")
+include("sampler.jl")
+include("sampling.jl")
 include("ladders.jl")
 include("stepping.jl")
 include("model.jl")
 
 export tempered,
+    tempered_sample,
     TemperedSampler,
     make_tempered_model,
     StandardSwap,

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -57,11 +57,11 @@ function sampler_for_process(sampler::TemperedSampler, state::TemperedState, I..
 end
 
 """
-    tempered(sampler, inverse_temperatures::Vector{<:Real}; kwargs...)
+    tempered(sampler, inverse_temperatures; kwargs...)
     OR
-    tempered(sampler, N_it::Integer; kwargs...)
+    tempered(sampler, N_it; swap_strategy=StandardSwap(), kwargs...)
 
-Return tempered version of `sampler` using the provided `inverse_temperatures` or
+Return a tempered version of `sampler` using the provided `inverse_temperatures` or
 inverse temperatures generated from `N_it` and the `swap_strategy`.
 
 # Arguments
@@ -69,7 +69,7 @@ inverse temperatures generated from `N_it` and the `swap_strategy`.
 - The temperature schedule can be defined either explicitly or just as an integer number of temperatures, i.e. as:
   - `inverse_temperatures` containing a sequence of 'inverse temperatures' {β₀, ..., βₙ} where 0 ≤ βₙ < ... < β₁ < β₀ = 1
         OR
-  - `N_it::Integer`, specifying the number of inverse temperatures to include in a generated `inverse_temperatures`
+  - `N_it`, specifying the integer number of inverse temperatures to include in a generated `inverse_temperatures`
 
 # Keyword arguments
 - `swap_strategy::AbstractSwapStrategy` is the way in which inverse temperature swaps between chains are made
@@ -84,24 +84,24 @@ inverse temperatures generated from `N_it` and the `swap_strategy`.
   - [`RandomPermutationSwap`](@ref)
 """
 function tempered(
-    sampler,
-    N_it::Integer,
-    swap_strategy::AbstractSwapStrategy = StandardSwap();
+    sampler::AbstractMCMC.AbstractSampler,
+    N_it::Integer;
+    swap_strategy::AbstractSwapStrategy=StandardSwap(),
     kwargs...
 )
     return tempered(sampler, generate_inverse_temperatures(N_it, swap_strategy); swap_strategy = swap_strategy, kwargs...)
 end
 function tempered(
-    sampler,
+    sampler::AbstractMCMC.AbstractSampler,
     inverse_temperatures::Vector{<:Real};
-    swap_strategy::AbstractSwapStrategy = StandardSwap(),
-    swap_every::Integer = 1,
-    adapt::Bool = true,
-    adapt_target::Real = 0.234,
-    adapt_stepsize::Real = 1,
-    adapt_eta::Real = 0.66,
-    adapt_schedule = Geometric(),
-    adapt_scale = defaultscale(adapt_schedule, inverse_temperatures),
+    swap_strategy::AbstractSwapStrategy=StandardSwap(),
+    swap_every::Integer=1,
+    adapt::Bool=false,
+    adapt_target::Real=0.234,
+    adapt_stepsize::Real=1,
+    adapt_eta::Real=0.66,
+    adapt_schedule=Geometric(),
+    adapt_scale=defaultscale(adapt_schedule, inverse_temperatures),
     kwargs...
 )
     swap_every >= 1 || error("This must be a positive integer.")

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -95,7 +95,7 @@ function tempered(
     sampler::AbstractMCMC.AbstractSampler,
     inverse_temperatures::Vector{<:Real};
     swap_strategy::AbstractSwapStrategy=StandardSwap(),
-    swap_every::Integer=1,
+    swap_every::Integer=2,
     adapt::Bool=false,
     adapt_target::Real=0.234,
     adapt_stepsize::Real=1,
@@ -104,7 +104,7 @@ function tempered(
     adapt_scale=defaultscale(adapt_schedule, inverse_temperatures),
     kwargs...
 )
-    swap_every >= 1 || error("This must be a positive integer.")
+    swap_every >= 2 || error("This must be a positive integer greater than 1.")
     inverse_temperatures = check_inverse_temperatures(inverse_temperatures)
     adaptation_states = init_adaptation(
         adapt_schedule, inverse_temperatures, adapt_target, adapt_scale, adapt_eta, adapt_stepsize

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,0 +1,53 @@
+"""
+    tempered_sample([rng, ], model, sampler, N, inverse_temperatures; kwargs...)
+    OR
+    tempered_sample([rng, ], model, sampler, N, N_it; swap_strategy=StandardSwap(), kwargs...)
+
+Generate `N` samples from `model` using a tempered version of the provided `sampler`.
+Provide either `inverse_temperatures` or `N_it` (and a `swap_strategy`) to generate some
+
+# Keyword arguments
+- `N_burnin::Integer` burn-in steps will be carried out before any swapping between chains is attempted
+- `swap_strategy::AbstractSwapStrategy` is the way in which inverse temperature swaps between chains are made
+- `swap_every::Integer` steps are carried out between each attempt at a swap
+
+# See also
+- [`tempered`](@ref)
+- [`TemperedSampler`](@ref)
+- For more on the swap strategies:
+  - [`AbstractSwapStrategy`](@ref)
+  - [`StandardSwap`](@ref)
+  - [`NonReversibleSwap`](@ref)
+  - [`RandomPermutationSwap`](@ref)
+"""
+function tempered_sample(
+    model,
+    sampler::AbstractMCMC.AbstractSampler,
+    N::Integer,
+    tempering_argument::Union{Integer, Vector{<:Real}};
+    kwargs...
+)
+    return tempered_sample(Random.default_rng(), model, sampler, N, tempering_argument; kwargs...)
+end
+function tempered_sample(
+    rng,
+    model,
+    sampler::AbstractMCMC.AbstractSampler,
+    N::Integer,
+    N_it::Integer;
+    swap_strategy::AbstractSwapStrategy = StandardSwap(),
+    kwargs...
+)
+    return tempered_sample(model, sampler, N, generate_inverse_temperatures(N_it, swap_strategy); swap_strategy=swap_strategy, kwargs...)
+end
+function tempered_sample(
+    rng,
+    model,
+    sampler::AbstractMCMC.AbstractSampler,
+    N::Integer,
+    inverse_temperatures::Vector{<:Real};
+    kwargs...
+)
+    tempered_sampler = tempered(sampler, inverse_temperatures; kwargs...)
+    return AbstractMCMC.sample(rng, model, tempered_sampler, N; kwargs...)
+end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -24,11 +24,12 @@ function tempered_sample(
     model,
     sampler::AbstractMCMC.AbstractSampler,
     N::Integer,
-    tempering_argument::Union{Integer, Vector{<:Real}};
+    arg::Union{Integer, Vector{<:Real}};
     kwargs...
 )
-    return tempered_sample(Random.default_rng(), model, sampler, N, tempering_argument; kwargs...)
+    return tempered_sample(Random.default_rng(), model, sampler, N, arg; kwargs...)
 end
+
 function tempered_sample(
     rng,
     model,
@@ -40,6 +41,7 @@ function tempered_sample(
 )
     return tempered_sample(model, sampler, N, generate_inverse_temperatures(N_it, swap_strategy); swap_strategy=swap_strategy, kwargs...)
 end
+
 function tempered_sample(
     rng,
     model,

--- a/src/state.jl
+++ b/src/state.jl
@@ -72,6 +72,8 @@ The indices here are exactly those represented by `states[k].chain_to_process[1]
     process_to_chain
     "total number of steps taken"
     total_steps
+    "number of burn-in steps taken"
+    burnin_steps
     "contains all necessary information for adaptation of inverse_temperatures"
     adaptation_states
     "flag which specifies wether this was a swap-step or not"

--- a/src/stepping.jl
+++ b/src/stepping.jl
@@ -1,5 +1,5 @@
 """
-should_swap(sampler, state)
+    should_swap(sampler, state)
 
 Return `true` if a swap should happen at this iteration, and `false` otherwise.
 """

--- a/src/stepping.jl
+++ b/src/stepping.jl
@@ -16,6 +16,7 @@ function AbstractMCMC.step(
     init_params=nothing,
     kwargs...
 )
+
     # `TemperedState` has the transitions and states in the order of
     # the processes, and performs swaps by moving the (inverse) temperatures
     # `β` between the processes, rather than moving states between processes

--- a/src/stepping.jl
+++ b/src/stepping.jl
@@ -1,5 +1,5 @@
 """
-    should_swap(sampler, state)
+should_swap(sampler, state)
 
 Return `true` if a swap should happen at this iteration, and `false` otherwise.
 """
@@ -11,6 +11,8 @@ function AbstractMCMC.step(
     rng::Random.AbstractRNG,
     model,
     sampler::TemperedSampler;
+    N_burnin::Integer=0,
+    burnin_progress::Bool=AbstractMCMC.PROGRESS[],
     init_params=nothing,
     kwargs...
 )
@@ -42,10 +44,31 @@ function AbstractMCMC.step(
         process_to_chain,
         chain_to_process,
         1,
+        0,
         sampler.adaptation_states,
         false,
         Dict{Int,Float64}()
     )
+
+    if N_burnin > 0
+        AbstractMCMC.@ifwithprogresslogger burnin_progress name = "Burn-in" begin
+            # Determine threshold values for progress logging
+            # (one update per 0.5% of progress)
+            if burnin_progress
+                threshold = N_burnin ÷ 200
+                next_update = threshold
+            end
+
+            for i in 1:N_burnin
+                if burnin_progress && i >= next_update
+                    ProgressLogging.@logprogress i / N_burnin
+                    next_update = i + threshold
+                end
+                state = no_swap_step(rng, model, sampler, state; kwargs...)
+                @set! state.burnin_steps += 1
+            end
+        end
+    end
 
     return transition_for_chain(state), state
 end
@@ -57,7 +80,6 @@ function AbstractMCMC.step(
     state::TemperedState;
     kwargs...
 )
-
     # Reset.
     @set! state.swap_acceptance_ratios = empty(state.swap_acceptance_ratios)
 


### PR DESCRIPTION
This PR adds two main things:

1. A `tempered_sample` helper function to allow a user to call directly with tempering related args without having to wrap a sampler. This facilitates more "standard" workflow from model => sampling, where a user may want to try many temperature ladders, swap strategies etc. on the same model. This does not replace or affect the pre-existing workflow of wrapping a sampler using the `tempered` function (perhaps this should be renamed `tempered_sampler`. This function made particular sense in context of (2) below..
2. No-swap burn-in functionality, i.e. a user can specify a set number of steps for the parallel tempered chains to be run *without* any attempts at swapping amongst them, this is a fairly standard part of the PT algorithm we did not support previously as it is hard to sensibly insert the necessary kwarg into the execution path to facilitate this. This is *distinct* from `discard_initial` in AbstractMCMC, as that functionality still works and would discard the initial M samples carried out under the full PT regime where swapping etc. may occur.

The implementation is roughly as follows:

Hi-jack the initial step unique call (where no state is present) to pass through burn-in related kwargs and trigger `N_burnin` samples to be made prior to starting the main PT regime.