### PR TITLE
Implementing and correcting the base set of swap strategies, plus wrapping swap moves as part of steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.6'
+          - '1.7'
           - '1'
         os:
           - ubuntu-latest

--- a/src/MCMCTempering.jl
+++ b/src/MCMCTempering.jl
@@ -27,9 +27,12 @@ export tempered,
     tempered_sample,
     TemperedSampler,
     make_tempered_model,
-    StandardSwap,
-    RandomPermutationSwap,
-    NonReversibleSwap
+    ReversibleSwap,
+    NonReversibleSwap,
+    SingleSwap,
+    SingleRandomSwap,
+    RandomSwap,
+    NoSwap
 
 # TODO: Should we make this trait-based instead?
 implements_logdensity(x) = LogDensityProblems.capabilities(x) !== nothing

--- a/src/ladders.jl
+++ b/src/ladders.jl
@@ -1,11 +1,14 @@
 """
-    get_scaling_val(N_it, swap_strategy)
+    get_scaling_val(N_it, <:AbstractSwapStrategy)
 
 Calculates a scaling factor for polynomial step size between inverse temperatures.
 """
-get_scaling_val(N_it, ::StandardSwap) = N_it - 1
+get_scaling_val(N_it, ::ReversibleSwap) = 2
 get_scaling_val(N_it, ::NonReversibleSwap) = 2
-get_scaling_val(N_it, ::RandomPermutationSwap) = 1
+get_scaling_val(N_it, ::SingleSwap) = N_it - 1
+get_scaling_val(N_it, ::SingleRandomSwap) = N_it - 1
+get_scaling_val(N_it, ::RandomSwap) = 1
+get_scaling_val(N_it, ::NoSwap) = N_it - 1
 
 """
     generate_inverse_temperatures(N_it, swap_strategy)

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -107,6 +107,7 @@ function tempered(
     adapt_scale=defaultscale(adapt_schedule, inverse_temperatures),
     kwargs...
 )
+    !(adapt && typeof(swap_strategy) <: Union{RandomSwap, SingleRandomSwap}) || error("Adaptation of the inverse temperature ladder is not currently supported under the chosen swap strategy.")
     swap_every > 1 || error("`swap_every` must take a positive integer value greater than 1.")
     inverse_temperatures = check_inverse_temperatures(inverse_temperatures)
     adaptation_states = init_adaptation(

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -107,7 +107,7 @@ function tempered(
     adapt_scale=defaultscale(adapt_schedule, inverse_temperatures),
     kwargs...
 )
-    swap_every > 0 || error("`swap_every` must take a positive integer value.")
+    swap_every > 1 || error("`swap_every` must take a positive integer value greater than 1.")
     inverse_temperatures = check_inverse_temperatures(inverse_temperatures)
     adaptation_states = init_adaptation(
         adapt_schedule, inverse_temperatures, adapt_target, adapt_scale, adapt_eta, adapt_stepsize

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,24 +1,27 @@
 """
     tempered_sample([rng, ], model, sampler, N, inverse_temperatures; kwargs...)
     OR
-    tempered_sample([rng, ], model, sampler, N, N_it; swap_strategy=StandardSwap(), kwargs...)
+    tempered_sample([rng, ], model, sampler, N, N_it; swap_strategy=SingleSwap(), kwargs...)
 
 Generate `N` samples from `model` using a tempered version of the provided `sampler`.
 Provide either `inverse_temperatures` or `N_it` (and a `swap_strategy`) to generate some
 
 # Keyword arguments
 - `N_burnin::Integer` burn-in steps will be carried out before any swapping between chains is attempted
-- `swap_strategy::AbstractSwapStrategy` is the way in which inverse temperature swaps between chains are made
+- `swap_strategy::AbstractSwapStrategy` specifies the method for swapping inverse temperatures between chains
 - `swap_every::Integer` steps are carried out between each attempt at a swap
 
 # See also
 - [`tempered`](@ref)
 - [`TemperedSampler`](@ref)
 - For more on the swap strategies:
-  - [`AbstractSwapStrategy`](@ref)
-  - [`StandardSwap`](@ref)
-  - [`NonReversibleSwap`](@ref)
-  - [`RandomPermutationSwap`](@ref)
+    - [`AbstractSwapStrategy`](@ref)
+    - [`ReversibleSwap`](@ref)
+    - [`NonReversibleSwap`](@ref)
+    - [`SingleSwap`](@ref)
+    - [`SingleRandomSwap`](@ref)
+    - [`RandomSwap`](@ref)
+    - [`NoSwap`](@ref)
 """
 function tempered_sample(
     model,
@@ -36,7 +39,7 @@ function tempered_sample(
     sampler::AbstractMCMC.AbstractSampler,
     N::Integer,
     N_it::Integer;
-    swap_strategy::AbstractSwapStrategy = StandardSwap(),
+    swap_strategy::AbstractSwapStrategy = SingleSwap(),
     kwargs...
 )
     return tempered_sample(model, sampler, N, generate_inverse_temperatures(N_it, swap_strategy); swap_strategy=swap_strategy, kwargs...)

--- a/src/stepping.jl
+++ b/src/stepping.jl
@@ -4,7 +4,7 @@
 Return `true` if a swap should happen at this iteration, and `false` otherwise.
 """
 function should_swap(sampler::TemperedSampler, state::TemperedState)
-    return state.total_steps % sampler.swap_every == 0
+    return state.total_steps % sampler.swap_every == 1
 end
 
 get_init_params(x, _)= x

--- a/src/stepping.jl
+++ b/src/stepping.jl
@@ -133,7 +133,7 @@ end
 """
     swap([strategy::AbstractSwapStrategy, ]rng, model, sampler, state)
 
-Return a new `state`, with temperatures potentially swapped according to `strategy`.
+Return a new `state`, with temperatures possibly swapped according to `strategy`.
 
 If no `strategy` is provided, the return-value of [`swapstrategy`](@ref) called on `sampler`
 is used.

--- a/src/swapping.jl
+++ b/src/swapping.jl
@@ -174,10 +174,10 @@ function swap_attempt(rng, model, sampler, state, i, j, adapt)
     # adapted before a new `inverse_temperatures` is generated and returned.
     if adapt
         ρs = adapt!!(
-            state.adaptation_states, state.inverse_temperatures, i, min(one(logα), exp(logα))
+            state.adaptation_states, state.chain_to_beta, i, min(one(logα), exp(logα))
         )
         @set! state.adaptation_states = ρs
-        @set! state.inverse_temperatures = update_inverse_temperatures(ρs, state.inverse_temperatures)
+        @set! state.chain_to_beta = update_inverse_temperatures(ρs, state.chain_to_beta)
     end
     return state
 end

--- a/src/swapping.jl
+++ b/src/swapping.jl
@@ -8,35 +8,26 @@ A concrete subtype is expected to implement the method [`swap_step`](@ref).
 abstract type AbstractSwapStrategy end
 
 """
-    StandardSwap <: AbstractSwapStrategy
+    ReversibleSwap <: AbstractSwapStrategy
 
-At every swap step taken, this strategy samples a single chain index `i` and proposes
-a swap between chains `i` and `i + 1`.
+Stochastically attempt either even- or odd-indexed swap moves between chains.
 
-This approach goes under a number of names, e.g. Parallel Tempering (PT) MCMC and Replica-Exchange MCMC.[^PTPH05]
+See [^SYED19] for more on this approach, referred to as SEO in their paper.
 
 # References
-[^PTPH05]: Earl, D. J., & Deem, M. W., Parallel tempering: theory, applications, and new perspectives, Physical Chemistry Chemical Physics, 7(23), 3910–3916 (2005).
+[^SYED19]: Syed, S., Bouchard-Côté, Alexandre, Deligiannidis, G., & Doucet, A., Non-reversible Parallel Tempering: A Scalable Highly Parallel MCMC Scheme, arXiv:1905.02939,  (2019).
 """
-struct StandardSwap <: AbstractSwapStrategy end
-
-"""
-    RandomPermutationSwap <: AbstractSwapStrategy
-
-At every swap step taken, this strategy randomly shuffles all the chain indices
-and then iterates through them, proposing swaps for neighboring chains.
-"""
-struct RandomPermutationSwap <: AbstractSwapStrategy end
-
+struct ReversibleSwap <: AbstractSwapStrategy end
 
 """
     NonReversibleSwap <: AbstractSwapStrategy
 
-At every swap step taken, this strategy _deterministically_ traverses first the
-odd chain indices, proposing swaps between neighbors, and then in the _next_ swap step
-taken traverses even chain indices, proposing swaps between neighbors.
+At every swap step taken, this strategy _deterministically_ traverses
+first the odd chain indices, proposing swaps between neighbors, and
+then in the _next_ swap step taken traverses even chain indices, proposing
+swaps between neighbors.
 
-See [^SYED19] for more on this approach.
+See [^SYED19] for more on this approach, referred to as DEO in their paper.
 
 # References
 [^SYED19]: Syed, S., Bouchard-Côté, Alexandre, Deligiannidis, G., & Doucet, A., Non-reversible Parallel Tempering: A Scalable Highly Parallel MCMC Scheme, arXiv:1905.02939,  (2019).
@@ -44,23 +35,67 @@ See [^SYED19] for more on this approach.
 struct NonReversibleSwap <: AbstractSwapStrategy end
 
 """
-    swap_betas!(chain_to_process, process_to_chain, k)
+    SingleSwap <: AbstractSwapStrategy
 
-Swaps the `k`th and `k + 1`th temperatures in place.
+At every swap step taken, this strategy samples a single chain index
+`i` and proposes a swap between chains `i` and `i + 1`.
+
+This approach goes under a number of names, e.g. Parallel Tempering
+(PT) MCMC and Replica-Exchange MCMC.[^PTPH05]
+
+# References
+[^PTPH05]: Earl, D. J., & Deem, M. W., Parallel tempering: theory, applications, and new perspectives, Physical Chemistry Chemical Physics, 7(23), 3910–3916 (2005).
 """
-function swap_betas!(chain_to_process, process_to_chain, k)
+struct SingleSwap <: AbstractSwapStrategy end
+
+"""
+    SingleRandomSwap <: AbstractSwapStrategy
+
+At every swap step taken, this strategy samples two chain indices
+`i` and 'j' and proposes a swap between the two corresponding chains.
+
+This approach is shown to be effective for certain models in [^1].
+
+# References
+[^1]: Malcolm Sambridge, A Parallel Tempering algorithm for probabilistic sampling and multimodal optimization, Geophysical Journal International, Volume 196, Issue 1, January 2014, Pages 357–374, https://doi.org/10.1093/gji/ggt342
+"""
+struct SingleRandomSwap <: AbstractSwapStrategy end
+
+"""
+    RandomSwap <: AbstractSwapStrategy
+
+This strategy randomly shuffles all the chain indices to produce
+`floor(numptemps(sampler)/2)` pairs of random (not necessarily
+neighbouring) chain indices to attempt to swap
+"""
+struct RandomSwap <: AbstractSwapStrategy end
+
+"""
+    NoSwap <: AbstractSwapStrategy
+
+Mainly useful for debugging or observing each chain independently,
+this overrides and disables all swapping functionality.
+"""
+struct NoSwap <: AbstractSwapStrategy end
+
+"""
+    swap_betas!(chain_to_process, process_to_chain, i, j)
+
+Swaps the `i`th and `j`th temperatures in place.
+"""
+function swap_betas!(chain_to_process, process_to_chain, i, j)
     # TODO: Use BangBang's `@set!!` to also support tuples?
     # Extract the process index for each of the chains.
-    process_for_chain_k, process_for_chain_kp1 = chain_to_process[k], chain_to_process[k + 1]
+    process_for_chain_i, process_for_chain_j = chain_to_process[i], chain_to_process[j]
 
     # Switch the mapping of the `chain → process` map.
-    # The temperature for the k-th chain will now be moved from its current process
-    # to the process for the (k + 1)-th chain, and vice versa.
-    chain_to_process[k], chain_to_process[k + 1] = process_for_chain_kp1, process_for_chain_k
+    # The temperature for the i-th chain will now be moved from its current process
+    # to the process for the (j)-th chain, and vice versa.
+    chain_to_process[i], chain_to_process[j] = process_for_chain_j, process_for_chain_i
 
     # Swap the mapping of the `process → chain` map.
-    # The process that used to have the k-th chain, now has the (k+1)-th chain, and vice versa.
-    process_to_chain[process_for_chain_k], process_to_chain[process_for_chain_kp1] = k + 1, k
+    # The process that used to have the i-th chain, now has the (i+1)-th chain, and vice versa.
+    process_to_chain[process_for_chain_i], process_to_chain[process_for_chain_j] = j, i
     return chain_to_process, process_to_chain
 end
 
@@ -89,58 +124,57 @@ function compute_tempered_logdensities(
 end
 
 """
-    swap_acceptance_pt(logπk, logπkp1)
+    swap_acceptance_pt(logπᵢ, logπⱼ)
 
 Calculates and returns the swap acceptance ratio for swapping the temperature
-of two chains. Using tempered likelihoods `logπk` and `logπkp1` at the chains'
+of two chains. Using tempered likelihoods `logπᵢ` and `logπⱼ` at the chains'
 current state parameters.
 """
-function swap_acceptance_pt(logπk_θk, logπk_θkp1, logπkp1_θk, logπkp1_θkp1)
-    return (logπkp1_θk + logπk_θkp1) - (logπk_θk + logπkp1_θkp1)
+function swap_acceptance_pt(logπᵢθᵢ, logπᵢθⱼ, logπⱼθᵢ, logπⱼθⱼ)
+    return (logπⱼθᵢ + logπᵢθⱼ) - (logπᵢθᵢ + logπⱼθⱼ)
 end
 
 
 """
-    swap_attempt(rng, model, sampler, state, k, adapt)
+    swap_attempt(rng, model, sampler, state, i, j)
 
 Attempt to swap the temperatures of two chains by tempering the densities and
 calculating the swap acceptance ratio; then swapping if it is accepted.
 """
-function swap_attempt(rng, model, sampler, state, k, adapt, total_steps)
-    # TODO: Allow arbitrary `k` rather than just `k + 1`.
+function swap_attempt(rng, model, sampler, state, i, j)
     # Extract the relevant transitions.
-    samplerk = sampler_for_chain(sampler, state, k)
-    samplerkp1 = sampler_for_chain(sampler, state, k + 1)
-    transitionk = transition_for_chain(state, k)
-    transitionkp1 = transition_for_chain(state, k + 1)
-    statek = state_for_chain(state, k)
-    statekp1 = state_for_chain(state, k + 1)
-    βk = beta_for_chain(state, k)
-    βkp1 = beta_for_chain(state, k + 1)
+    samplerᵢ = sampler_for_chain(sampler, state, i)
+    samplerⱼ = sampler_for_chain(sampler, state, j)
+    transitionᵢ = transition_for_chain(state, i)
+    transitionⱼ = transition_for_chain(state, j)
+    stateᵢ = state_for_chain(state, i)
+    stateⱼ = state_for_chain(state, j)
+    βᵢ = beta_for_chain(state, i)
+    βⱼ = beta_for_chain(state, j)
     # Evaluate logdensity for both parameters for each tempered density.
-    logπk_θk, logπk_θkp1 = compute_tempered_logdensities(
-        model, samplerk, samplerkp1, transitionk, transitionkp1, statek, statekp1, βk, βkp1
+    logπᵢθᵢ, logπᵢθⱼ = compute_tempered_logdensities(
+        model, samplerᵢ, samplerⱼ, transitionᵢ, transitionⱼ, stateᵢ, stateⱼ, βᵢ, βⱼ
     )
-    logπkp1_θkp1, logπkp1_θk = compute_tempered_logdensities(
-        model, samplerkp1, samplerk, transitionkp1, transitionk, statekp1, statek, βkp1, βk
+    logπⱼθⱼ, logπⱼθᵢ = compute_tempered_logdensities(
+        model, samplerⱼ, samplerᵢ, transitionⱼ, transitionᵢ, stateⱼ, stateᵢ, βⱼ, βᵢ
     )
     
     # If the proposed temperature swap is accepted according `logα`,
     # swap the temperatures for future steps.
-    logα = swap_acceptance_pt(logπk_θk, logπk_θkp1, logπkp1_θk, logπkp1_θkp1)
+    logα = swap_acceptance_pt(logπᵢθᵢ, logπᵢθⱼ, logπⱼθᵢ, logπⱼθⱼ)
     should_swap = -Random.randexp(rng) ≤ logα
     if should_swap
-        swap_betas!(state.chain_to_process, state.process_to_chain, k)
+        swap_betas!(state.chain_to_process, state.process_to_chain, i, j)
     end
 
     # Keep track of the (log) acceptance ratios.
-    state.swap_acceptance_ratios[k] = logα
+    state.swap_acceptance_ratios[i] = logα
 
     # Adaptation steps affects `ρs` and `inverse_temperatures`, as the `ρs` is
     # adapted before a new `inverse_temperatures` is generated and returned.
-    if adapt
+    if sampler.adapt
         ρs = adapt!!(
-            state.adaptation_states, state.inverse_temperatures, k, min(one(logα), exp(logα))
+            state.adaptation_states, state.inverse_temperatures, i, min(one(logα), exp(logα))
         )
         @set! state.adaptation_states = ρs
         @set! state.inverse_temperatures = update_inverse_temperatures(ρs, state.inverse_temperatures)

--- a/src/swapping.jl
+++ b/src/swapping.jl
@@ -141,7 +141,7 @@ end
 Attempt to swap the temperatures of two chains by tempering the densities and
 calculating the swap acceptance ratio; then swapping if it is accepted.
 """
-function swap_attempt(rng, model, sampler, state, i, j)
+function swap_attempt(rng, model, sampler, state, i, j, adapt)
     # Extract the relevant transitions.
     sampler_i = sampler_for_chain(sampler, state, i)
     sampler_j = sampler_for_chain(sampler, state, j)
@@ -172,7 +172,7 @@ function swap_attempt(rng, model, sampler, state, i, j)
 
     # Adaptation steps affects `ρs` and `inverse_temperatures`, as the `ρs` is
     # adapted before a new `inverse_temperatures` is generated and returned.
-    if sampler.adapt
+    if adapt
         ρs = adapt!!(
             state.adaptation_states, state.inverse_temperatures, i, min(one(logα), exp(logα))
         )

--- a/src/swapping.jl
+++ b/src/swapping.jl
@@ -124,14 +124,14 @@ function compute_tempered_logdensities(
 end
 
 """
-    swap_acceptance_pt(logπᵢ, logπⱼ)
+    swap_acceptance_pt(logπi, logπj)
 
 Calculates and returns the swap acceptance ratio for swapping the temperature
-of two chains. Using tempered likelihoods `logπᵢ` and `logπⱼ` at the chains'
+of two chains. Using tempered likelihoods `logπi` and `logπj` at the chains'
 current state parameters.
 """
-function swap_acceptance_pt(logπᵢθᵢ, logπᵢθⱼ, logπⱼθᵢ, logπⱼθⱼ)
-    return (logπⱼθᵢ + logπᵢθⱼ) - (logπᵢθᵢ + logπⱼθⱼ)
+function swap_acceptance_pt(logπiθi, logπiθj, logπjθi, logπjθj)
+    return (logπjθi + logπiθj) - (logπiθi + logπjθj)
 end
 
 
@@ -143,25 +143,25 @@ calculating the swap acceptance ratio; then swapping if it is accepted.
 """
 function swap_attempt(rng, model, sampler, state, i, j)
     # Extract the relevant transitions.
-    samplerᵢ = sampler_for_chain(sampler, state, i)
-    samplerⱼ = sampler_for_chain(sampler, state, j)
-    transitionᵢ = transition_for_chain(state, i)
-    transitionⱼ = transition_for_chain(state, j)
-    stateᵢ = state_for_chain(state, i)
-    stateⱼ = state_for_chain(state, j)
-    βᵢ = beta_for_chain(state, i)
-    βⱼ = beta_for_chain(state, j)
+    sampler_i = sampler_for_chain(sampler, state, i)
+    sampler_j = sampler_for_chain(sampler, state, j)
+    transition_i = transition_for_chain(state, i)
+    transition_j = transition_for_chain(state, j)
+    state_i = state_for_chain(state, i)
+    state_j = state_for_chain(state, j)
+    β_i = beta_for_chain(state, i)
+    β_j = beta_for_chain(state, j)
     # Evaluate logdensity for both parameters for each tempered density.
-    logπᵢθᵢ, logπᵢθⱼ = compute_tempered_logdensities(
-        model, samplerᵢ, samplerⱼ, transitionᵢ, transitionⱼ, stateᵢ, stateⱼ, βᵢ, βⱼ
+    logπiθi, logπiθj = compute_tempered_logdensities(
+        model, sampler_i, sampler_j, transition_i, transition_j, state_i, state_j, β_i, β_j
     )
-    logπⱼθⱼ, logπⱼθᵢ = compute_tempered_logdensities(
-        model, samplerⱼ, samplerᵢ, transitionⱼ, transitionᵢ, stateⱼ, stateᵢ, βⱼ, βᵢ
+    logπjθj, logπjθi = compute_tempered_logdensities(
+        model, sampler_j, sampler_i, transition_j, transition_i, state_j, state_i, β_j, β_i
     )
     
     # If the proposed temperature swap is accepted according `logα`,
     # swap the temperatures for future steps.
-    logα = swap_acceptance_pt(logπᵢθᵢ, logπᵢθⱼ, logπⱼθᵢ, logπⱼθⱼ)
+    logα = swap_acceptance_pt(logπiθi, logπiθj, logπjθi, logπjθj)
     should_swap = -Random.randexp(rng) ≤ logα
     if should_swap
         swap_betas!(state.chain_to_process, state.process_to_chain, i, j)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,7 @@ function test_and_sample_model(
     model,
     sampler,
     inverse_temperatures,
-    swap_strategy=MCMCTempering.StandardSwap();
+    swap_strategy=MCMCTempering.SingleSwap();
     mean_swap_rate_bound=0.1,
     compare_mean_swap_rate=≥,
     num_iterations=2_000,
@@ -325,9 +325,11 @@ end
 
         # Different swap strategies to test.
         swapstrategies = [
-            MCMCTempering.StandardSwap(),
-            MCMCTempering.RandomPermutationSwap(),
-            MCMCTempering.NonReversibleSwap()
+            MCMCTempering.ReversibleSwap(),
+            MCMCTempering.NonReversibleSwap(),
+            MCMCTempering.SingleSwap(),
+            MCMCTempering.SingleRandomSwap(),
+            MCMCTempering.RandomSwap()
         ]
 
         @testset "$(swapstrategy)" for swapstrategy in swapstrategies
@@ -428,7 +430,7 @@ end
                 model,
                 sampler_mh,
                 [1, 0.9, 0.75, 0.5, 0.25, 0.1],
-                swap_strategy=MCMCTempering.StandardSwap(),
+                swap_strategy=MCMCTempering.ReversibleSwap(),
                 num_iterations=num_iterations,
                 swap_every=2,
                 adapt=false,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,7 +355,7 @@ end
         # Get the parameter names.
         param_names = map(Symbol, DynamicPPL.TestUtils.varnames(model_dppl))
         # Get bijector so we can get back to unconstrained space afterwards.
-        b = inv(Turing.bijector(model_dppl))
+        b = inverse(Turing.bijector(model_dppl))
         # Construct the `LogDensityFunction` which supports LogDensityProblems.jl-interface.
         model = ADgradient(:ForwardDiff, DynamicPPL.LogDensityFunction(model_dppl, vi))
 
@@ -368,7 +368,7 @@ end
         end
 
         @testset "AdvancedHMC.jl" begin
-            num_iterations = 10_000
+            num_iterations = 20_000
 
             # Set up HMC smpler.
             initial_ϵ = 0.1
@@ -389,7 +389,7 @@ end
             chain_tempered = test_and_sample_model(
                 model,
                 sampler_hmc,
-                [1, 0.5, 0.1],
+                [1, 0.25, 0.1, 0.01],
                 swap_strategy=MCMCTempering.ReversibleSwap(),
                 num_iterations=num_iterations,
                 swap_every=10,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,7 +215,7 @@ end
         chain_to_beta = [1.0, 0.75, 0.5, 0.25]
 
         # Make swap chain 1 (now on process 1) ↔ chain 2 (now on process 2)
-        MCMCTempering.swap_betas!(chain_to_process, process_to_chain, 1)
+        MCMCTempering.swap_betas!(chain_to_process, process_to_chain, 1, 2)
         # Expected result: chain 1 is now on process 2, chain 2 is now on process 1.
         target_process_to_chain = [2, 1, 3, 4]
         @test process_to_chain[chain_to_process] == 1:length(process_to_chain)
@@ -231,7 +231,7 @@ end
         end
 
         # Make swap chain 2 (now on process 1) ↔ chain 3 (now on process 3)
-        MCMCTempering.swap_betas!(chain_to_process, process_to_chain, 2)
+        MCMCTempering.swap_betas!(chain_to_process, process_to_chain, 2, 3)
         # Expected result: chain 3 is now on process 1, chain 2 is now on process 3.
         target_process_to_chain = [3, 1, 2, 4]
         @test process_to_chain[chain_to_process] == 1:length(process_to_chain)
@@ -271,6 +271,7 @@ end
         # `atol` is fairly high because we haven't run this for "too" long. 
         @test mean(chain_tempered[:, 1, :]) ≈ 1 atol=0.2
     end
+
     @testset "GMM 1D" begin
         num_iterations = 10_000
         model = DistributionLogDensity(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -368,14 +368,15 @@ end
         end
 
         @testset "AdvancedHMC.jl" begin
-            num_iterations = 20_000
+            num_iterations = 2_000
 
             # Set up HMC smpler.
             initial_ϵ = 0.1
             integrator = AdvancedHMC.Leapfrog(initial_ϵ)
             proposal = AdvancedHMC.NUTS{AdvancedHMC.MultinomialTS, AdvancedHMC.GeneralisedNoUTurn}(integrator)
             metric = AdvancedHMC.DiagEuclideanMetric(LogDensityProblems.dimension(model))
-            sampler_hmc = AdvancedHMC.HMCSampler(proposal, metric)
+            adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))
+            sampler_hmc = AdvancedHMC.HMCSampler(proposal, metric, adaptor)
 
             # Sample using HMC.
             samples_hmc = sample(model, sampler_hmc, num_iterations; init_params=copy(init_params), progress=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -375,7 +375,7 @@ end
             integrator = AdvancedHMC.Leapfrog(initial_ϵ)
             proposal = AdvancedHMC.NUTS{AdvancedHMC.MultinomialTS, AdvancedHMC.GeneralisedNoUTurn}(integrator)
             metric = AdvancedHMC.DiagEuclideanMetric(LogDensityProblems.dimension(model))
-            adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))
+            adaptor = AdvancedHMC.StanHMCAdaptor(AdvancedHMC.MassMatrixAdaptor(metric), AdvancedHMC.StepSizeAdaptor(0.8, integrator))
             sampler_hmc = AdvancedHMC.HMCSampler(proposal, metric, adaptor)
 
             # Sample using HMC.


### PR DESCRIPTION
Contributions:

- ~~Merged the swap move part of a step with the step itself:~~
  - ~~Rather than having some steps returned by `AbstractMCMC.sample` that correspond only to the result of swapping temperatures between chains, we carry out the check for whether we `should_swap` and do the `swap` itself as part of the `AbstractMCMC.step` and _always_ progress the chains using the underlying exploratory samplers / kernels as well, this leads to a 1:1 correspondence between `nsamples` specified at sample time and the total number of steps taken by the samplers, which is desirable.~~
- Implementations of standard swap strategies:
  - Provide correct implementations of `SingleRandomSwap`, `RandomSwap`, `ReversibleSwap` and `NonReversibleSwap` in line with their definitions in the referenced literature. Reversible and Non-Reversible schemes are particularly important for reasonable baseline performance of a functional PT package, as they increase our robustness to untuned temperature ladders.
  - Renamed `StandardSwap` to `SingleSwap` for clarity.
  - Added `NoSwap` for debugging / disabling of swap functionality.
- Cleaned up `swapping.jl`:
  - Generalised to accept `i` and `j` inverse temperature indices to do a swap between.
  - Removed unnecessary arguments from `swap_attempt` (we weren't using the `total_steps` functions in adaptation anyway, unless I am missing something?)
  - Clearer variable names and references
- Adaptation is not supported for `RandomSwap` and `SingleRandomSwap`, due to them involving swaps between non-neighbouring chains. Worth noting it doesnt seem to work well in general currently. Have added a check and raise for the situation where user tries to adapt under these strategies.

Pending TODO:

- Could further clean up `swapping.jl` by renaming the variables ending in `_other`, potentially remove the versions of functions that take many args given we are explicitly supporting `LogDensityProblems` as a base for most of we want to do for now, could add back more complex signatures for things like `compute_tempered_logdensities` if required down the line.
